### PR TITLE
Fix: Webkit issue with cached images not triggering a load event.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,10 @@ export default function (elem, opts) {
 	}
 
 	forEach(elem, el => {
-		const img = new Image();
-		img.src = el.src;
-		img.onload = onload;
-		img.onerror = onerror;
+		const src = el.src;
+		el.src = '';
+		el.src = src;
+		el.onload = onload;
+		el.onerror = onerror;
 	});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,9 @@ export default function (elem, opts) {
 	}
 
 	forEach(elem, el => {
-		el.onload = onload;
-		el.onerror = onerror;
+		const img = new Image();
+		img.src = el.src;
+		img.onload = onload;
+		img.onerror = onerror;
 	});
 }


### PR DESCRIPTION
We had an issue where in safari images would not appear when they are cached in the browser.

This pull request applies a small "hack" to fix this in Webkit.

Source:
https://stackoverflow.com/questions/5024111/javascript-image-onload-doesnt-fire-in-webkit-if-loading-same-image